### PR TITLE
menoh-1.1.1_1

### DIFF
--- a/Formula/menoh.rb
+++ b/Formula/menoh.rb
@@ -2,16 +2,36 @@ class Menoh < Formula
   desc "DNN inference library with MKL-DNN"
   homepage "https://github.com/pfnet-research/menoh/"
   # pull from git tag to get submodules
-  url "https://github.com/pfnet-research/menoh.git", :tag => "v1.1.1",
-                                                     :revision => "1b8e00f80e4342043097f5336d6f656951249308"
+  url "https://github.com/pfnet-research/menoh.git",
+      tag:      "v1.1.1",
+      revision: "1b8e00f80e4342043097f5336d6f656951249308"
+  revision 1
   head "https://github.com/pfnet-research/menoh.git"
 
+  keg_only "it conflicts with the onednn formula"
+
   depends_on "cmake" => :build
-  depends_on "mkl-dnn"
   depends_on "protobuf"
 
+  resource "mkldnn" do
+    url "https://github.com/intel/mkl-dnn/archive/v0.16.tar.gz"
+    sha256 "bbde839f5100855577cb781fc5c69e9661f2fdbab6b4da8ebe660fb887d00429"
+  end
+
   def install
-    system "cmake", ".", "-DENABLE_EXAMPLE=OFF", *std_cmake_args
+    resource("mkldnn").stage do
+      system "cmake",
+             "-DCMAKE_BUILD_TYPE=Release",
+             "-DWITH_TEST=OFF",
+             "-DWITH_EXAMPLE=OFF",
+             "-DARCH_OPT_FLAGS=''",
+             "-DCMAKE_INSTALL_RPATH=#{rpath}",
+             "-Wno-error=unused-result",
+              ".", *std_cmake_args
+      system "make", "install"
+    end
+
+    system "cmake", ".", "-DENABLE_EXAMPLE=OFF", "-DCMAKE_INSTALL_RPATH=#{rpath}", *std_cmake_args
     system "make", "install"
   end
 


### PR DESCRIPTION
As current Menoh does not work recent version of mkldnn (oneDNN), we fix `menoh` formula to use older version instead of the one provided by Homebrew.